### PR TITLE
[New Feature] Add command to use items

### DIFF
--- a/SomethingNeedDoing/Grammar/Commands/ItemCommand.cs
+++ b/SomethingNeedDoing/Grammar/Commands/ItemCommand.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using SomethingNeedDoing.Exceptions;
+using SomethingNeedDoing.Grammar.Modifiers;
+using SomethingNeedDoing.Misc;
+
+using Sheets = Lumina.Excel.GeneratedSheets;
+
+namespace SomethingNeedDoing.Grammar.Commands;
+
+/// <summary>
+/// The /item command.
+/// </summary>
+internal class ItemCommand : MacroCommand
+{
+    private static readonly Regex Regex = new(@"^/item\s+(?<name>.*?)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private readonly string itemName;
+    private readonly ItemQualityModifier itemQualityMod;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ItemCommand"/> class.
+    /// </summary>
+    /// <param name="text">Original text.</param>
+    /// <param name="itemName">Item name.</param>
+    /// <param name="wait">Wait value.</param>
+    /// <param name="itemQualityMod">Required quality of the item used.</param>
+    private ItemCommand(string text, string itemName, WaitModifier wait, ItemQualityModifier itemQualityMod)
+        : base(text, wait)
+    {
+        this.itemName = itemName.ToLowerInvariant();
+        this.itemQualityMod = itemQualityMod;
+    }
+
+    /// <summary>
+    /// Parse the text as a command.
+    /// </summary>
+    /// <param name="text">Text to parse.</param>
+    /// <returns>A parsed command.</returns>
+    public static ItemCommand Parse(string text)
+    {
+        _ = WaitModifier.TryParse(ref text, out var waitModifier);
+        _ = ItemQualityModifier.TryParse(ref text, out var itemQualityModifier);
+
+        var match = Regex.Match(text);
+        if (!match.Success)
+            throw new MacroSyntaxError(text);
+
+        var nameValue = ExtractAndUnquote(match, "name");
+
+        return new ItemCommand(text, nameValue, waitModifier, itemQualityModifier);
+    }
+
+    /// <inheritdoc/>
+    public async override Task Execute(ActiveMacro macro, CancellationToken token)
+    {
+        PluginLog.Debug($"Executing: {this.Text}");
+
+        var itemId = this.SearchItemId(this.itemName);
+        PluginLog.Debug($"Item found: {itemId}");
+
+        var count = this.GetInventoryItemCount(itemId, this.itemQualityMod.IsHq);
+        PluginLog.Debug($"Item Count: {count}");
+        if (count == 0)
+            throw new MacroCommandError("You do not have that item");
+
+        this.UseItem(itemId, this.itemQualityMod.IsHq);
+
+        await this.PerformWait(token);
+    }
+
+    private unsafe void UseItem(uint itemID, bool isHQ = false)
+    {
+        var agent = AgentInventoryContext.Instance();
+        if (agent == null)
+            throw new MacroCommandError("AgentInventoryContext not found");
+
+        if (isHQ)
+            itemID += 1_000_000;
+
+        var result = agent->UseItem(itemID);
+        if (result != 0)
+            throw new MacroCommandError("Failed to use item");
+    }
+
+    private unsafe int GetInventoryItemCount(uint itemID, bool isHQ)
+    {
+        var inventoryManager = InventoryManager.Instance();
+        if (inventoryManager == null)
+            throw new MacroCommandError("InventoryManager not found");
+
+        return inventoryManager->GetInventoryItemCount(itemID, isHQ);
+    }
+
+    private uint SearchItemId(string itemName)
+    {
+        var sheet = Service.DataManager.GetExcelSheet<Sheets.Item>()!;
+        var item = sheet.FirstOrDefault(r => r.Name.ToString().ToLowerInvariant() == itemName);
+        if (item == null)
+            throw new MacroCommandError("Item not found");
+
+        return item.RowId;
+    }
+}

--- a/SomethingNeedDoing/Grammar/MacroParser.cs
+++ b/SomethingNeedDoing/Grammar/MacroParser.cs
@@ -59,6 +59,7 @@ internal static class MacroParser
             "/click" => ClickCommand.Parse(line),
             "/craft" => GateCommand.Parse(line),
             "/gate" => GateCommand.Parse(line),
+            "/item" => ItemCommand.Parse(line),
             "/loop" => LoopCommand.Parse(line),
             "/recipe" => RecipeCommand.Parse(line),
             "/require" => RequireCommand.Parse(line),

--- a/SomethingNeedDoing/Grammar/Modifiers/ItemQualityModifier.cs
+++ b/SomethingNeedDoing/Grammar/Modifiers/ItemQualityModifier.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SomethingNeedDoing.Grammar.Modifiers;
+
+/// <summary>
+/// The &lt;itemquality&gt; modifier.
+/// </summary>
+internal class ItemQualityModifier : MacroModifier
+{
+    private static readonly Regex Regex = new(@"(?<modifier><hq>)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private ItemQualityModifier(bool isHQ)
+    {
+        this.IsHq = isHQ;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the hq item is used.
+    /// </summary>
+    public bool IsHq { get; }
+
+    /// <summary>
+    /// Parse the text as a modifier.
+    /// </summary>
+    /// <param name="text">Text to parse.</param>
+    /// <param name="command">A parsed modifier.</param>
+    /// <returns>A value indicating whether the modifier matched.</returns>
+    public static bool TryParse(ref string text, out ItemQualityModifier command)
+    {
+        var match = Regex.Match(text);
+        var success = match.Success;
+
+        if (success)
+        {
+            var group = match.Groups["modifier"];
+            text = text.Remove(group.Index, group.Length);
+        }
+
+        command = new ItemQualityModifier(success);
+
+        return success;
+    }
+}


### PR DESCRIPTION
Add command to use items

example)
Use NQ Portion:  `/item portion`
Use HQ Portion:  `/item portion <hq>`

Depends on [this](https://github.com/marimelon/FFXIVClientStructs/commit/b55c9d7aa379bff0781b3b04c8f33d44672200c8) commit.