### PR TITLE
Add parameter to NeedsRepair, Add /item documentation

### DIFF
--- a/SomethingNeedDoing/Interface/HelpWindow.cs
+++ b/SomethingNeedDoing/Interface/HelpWindow.cs
@@ -106,6 +106,15 @@ internal class HelpWindow : Window
                 "/requirestats 2700 2600 500",
             }),
         (
+            "item", null,
+            "Use an item, stopping the macro if the item is not present.",
+            new[] { "hq", "wait" },
+            new[]
+            {
+                "/item Calamari Ripieni",
+                "/item Calamari Ripieni <hq> <wait.3>",
+            }),
+        (
             "runmacro", null,
             "Start a macro from within another macro.",
             new[] { "wait" },

--- a/SomethingNeedDoing/Misc/CommandInterface.cs
+++ b/SomethingNeedDoing/Misc/CommandInterface.cs
@@ -158,7 +158,7 @@ public class CommandInterface : ICommandInterface
     }
 
     /// <inheritdoc/>
-    public unsafe bool NeedsRepair()
+    public unsafe bool NeedsRepair(float below = 0)
     {
         var im = InventoryManager.Instance();
         if (im == null)
@@ -186,7 +186,9 @@ public class CommandInterface : ICommandInterface
             if (item == null)
                 continue;
 
-            if (item->Condition == 0)
+            var itemCondition = Convert.ToInt32(Convert.ToDouble(item->Condition) / 30000.0 * 100.0);
+
+            if (itemCondition <= below)
                 return true;
         }
 

--- a/SomethingNeedDoing/Misc/ICommandInterface.cs
+++ b/SomethingNeedDoing/Misc/ICommandInterface.cs
@@ -114,8 +114,9 @@ public interface ICommandInterface
     /// <summary>
     /// Gets a value indicating whether any of the player's worn equipment is broken.
     /// </summary>
+    /// <param name="below">Return true if the gear durability is less than or eqal to this number.</param>
     /// <returns>A value indicating whether any of the player's worn equipment is broken.</returns>
-    public bool NeedsRepair();
+    public bool NeedsRepair(float below = 0);
 
     /// <summary>
     /// Gets a value indicating whether any of the player's worn equipment can have materia extracted.


### PR DESCRIPTION
Add parameter to NeedsRepair which lets the lua macro-writer decide the level at which items need repaired, versus only returning true when broken.

This way you can have gear repaired if it's broken at all, or below a certain threshold, enabling repair macros to be done between larger chunks of crafting versus your current options of stopping when gear is broken or checking if a repair needs done between every single craft.